### PR TITLE
Removed redundant model, Use roomAssociation instead [#158037410]

### DIFF
--- a/projects/revaturecloud/selection/src/lib/models/address.model.ts
+++ b/projects/revaturecloud/selection/src/lib/models/address.model.ts
@@ -1,4 +1,25 @@
-// Subject to change
+///  <summary>
+///    An object representing the Address field in the
+///    User and Room objects returned in the housing selection API.
+///  </summary>
+///  <remarks>
+///    Endpoints which return this object as a nested object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Housing-Selection-API-Endpionts"
+///      (GET) All Rooms - /Rooms
+///      (GET) All Rooms in One Location - /Rooms/ComplexObject
+///      (GET) All Rooms With Unassigned Bed By Gender - /Rooms/ComplexObject
+///      (GET) All Rooms With All Unassigned Bed By Gender - /Rooms/ComplexObject
+///      (GET) All Rooms With Unassigned Bed By Gender/Batch Percentage - /Rooms/ComplexObject
+///      (GET) All Users - /Users
+///      (GET) All Users Without A Room - /Users/Unassigned
+///
+///    The service-hub-housing-wiki's page on this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Room-Model"
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/User-Model"
+///      Address - Custom Class
+///      Address - Street - string, APT - string
+///      City - string, State - string, PostalCode - string, Country - string
+///  </remarks>
 
 export class Address {
   Street: string;

--- a/projects/revaturecloud/selection/src/lib/models/batch.model.ts
+++ b/projects/revaturecloud/selection/src/lib/models/batch.model.ts
@@ -1,4 +1,15 @@
-// Subject to change
+///  <summary>
+///    An object representing the expected output from the
+///    housing selection API endpoint "/Batches/".
+///  </summary>
+///  <remarks>
+///    Endpoints which return this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Housing-Selection-API-Endpionts"
+///      (GET) All Batches - /Batches
+///
+///    The service-hub-housing-wiki's page on this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Batch-Model"
+///  </remarks>
 
 export class Batch {
   BatchId: string;

--- a/projects/revaturecloud/selection/src/lib/models/name.model.ts
+++ b/projects/revaturecloud/selection/src/lib/models/name.model.ts
@@ -1,4 +1,17 @@
-// Subject to change
+///  <summary>
+///    An object representing the Name field in the
+///    User object returned in the housing selection API.
+///  </summary>
+///  <remarks>
+///    Endpoints which return this object as a nested object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Housing-Selection-API-Endpionts"
+///      (GET) All Users - /Users
+///      (GET) All Users Without A Room - /Users/Unassigned
+///
+///    The service-hub-housing-wiki's page on this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/User-Model"
+///      Name - Custom class First - string, Middle - string, Last - string
+///  </remarks>
 
 export class Name {
   First: string;

--- a/projects/revaturecloud/selection/src/lib/models/put-request.model.ts
+++ b/projects/revaturecloud/selection/src/lib/models/put-request.model.ts
@@ -1,6 +1,0 @@
-// Subject to change
-
-export class PutRequest {
-  UserId: string;
-  RoomId: string;
-}

--- a/projects/revaturecloud/selection/src/lib/models/room.model.ts
+++ b/projects/revaturecloud/selection/src/lib/models/room.model.ts
@@ -1,4 +1,20 @@
-// Subject to change
+///  <summary>
+///    An object representing the expected output from the
+///    housing selection API endpoints "/Rooms/" and "/Rooms/ComplexObject".
+///  </summary>
+///  <remarks>
+///    Endpoints which return this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Housing-Selection-API-Endpionts"
+///      (GET) All Rooms - /Rooms
+///      (GET) All Rooms in One Location - /Rooms/ComplexObject
+///      (GET) All Rooms With Unassigned Bed By Gender - /Rooms/ComplexObject
+///      (GET) All Rooms With All Unassigned Bed By Gender - /Rooms/ComplexObject
+///      (GET) All Rooms With Unassigned Bed By Gender/Batch Percentage - /Rooms/ComplexObject
+///
+///    The service-hub-housing-wiki's page on this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Room-Model"
+///  </remarks>
+
 import { Address } from "./address.model";
 
 export class Room {

--- a/projects/revaturecloud/selection/src/lib/models/user.model.ts
+++ b/projects/revaturecloud/selection/src/lib/models/user.model.ts
@@ -1,3 +1,17 @@
+///  <summary>
+///    An object representing the expected output from the
+///    housing selection API endpoints "/Users/" and "/Users/Unassigned".
+///  </summary>
+///  <remarks>
+///    Endpoints which return this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/Housing-Selection-API-Endpionts"
+///      (GET) All Users - /Users
+///      (GET) All Users Without A Room - /Users/Unassigned
+///
+///    The service-hub-housing-wiki's page on this object:
+///    "https://github.com/mjbradvica/service-hub-housing-ui-wiki/wiki/User-Model"
+///  </remarks>
+
 import { Address } from "./address.model";
 import { Name } from "./name.model";
 


### PR DESCRIPTION
Removed a redundant model "put-request.model.ts" in favor of "roomAssociaiton.model.ts".

Added /// documentation to the rest of the models.